### PR TITLE
Build dummy payloads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,9 @@ pub struct Config {
     /// Number of recent forkchoiceUpdated messages to cache in memory.
     #[arg(long, value_name = "N", default_value = "64")]
     pub fcu_cache_size: usize,
+    /// Number of payload attributes and past payloads to cache in memory.
+    #[arg(long, value_name = "N", default_value = "8")]
+    pub payload_builder_cache_size: usize,
     /// Number of justified block hashes to cache in memory.
     #[arg(long, value_name = "N", default_value = "4")]
     pub justified_block_cache_size: usize,

--- a/src/fcu.rs
+++ b/src/fcu.rs
@@ -3,8 +3,9 @@ use crate::{
     config::FcuMatching,
     multiplexer::Multiplexer,
     types::{
-        ErrorResponse, JsonForkchoiceStateV1, JsonForkchoiceUpdatedV1Response, JsonPayloadStatusV1,
-        JsonPayloadStatusV1Status, JsonValue, Request, Response,
+        ErrorResponse, JsonForkchoiceStateV1, JsonForkchoiceUpdatedV1Response,
+        JsonPayloadAttributes, JsonPayloadStatusV1, JsonPayloadStatusV1Status, Request, Response,
+        TransparentJsonPayloadId,
     },
 };
 use eth2::types::EthSpec;
@@ -12,17 +13,19 @@ use std::time::{Duration, Instant};
 
 impl<E: EthSpec> Multiplexer<E> {
     pub async fn handle_controller_fcu(&self, request: Request) -> Result<Response, ErrorResponse> {
-        let (id, (fcu, _payload_attributes)) =
-            request.parse_as::<(JsonForkchoiceStateV1, JsonValue)>()?;
+        // FIXME: might need ForkVersionDeserialize for payload attributes
+        let (id, (fcu, opt_payload_attributes)) =
+            request.parse_as::<(JsonForkchoiceStateV1, Option<JsonPayloadAttributes>)>()?;
 
         let head_hash = fcu.head_block_hash;
         tracing::info!(head_hash = ?head_hash, "processing fcU from controller");
 
-        let response = if let Some(response) = self.get_cached_fcu(&fcu, true).await {
-            response
+        let payload_status = if let Some(status) = self.get_cached_fcu(&fcu, true).await {
+            // If fcU is cached then there should also
+            status
         } else {
             // Make a corresponding request to the EL.
-            // Never send payload attributes.
+            // Do not send payload attributes to the EL (for now).
             match self
                 .engine
                 .notify_forkchoice_updated(fcu.clone().into(), None, &self.log)
@@ -34,40 +37,43 @@ impl<E: EthSpec> Multiplexer<E> {
 
                     let mut cache = self.fcu_cache.lock().await;
 
-                    let cached = if let Some(existing_entry) = cache.get_mut(&fcu) {
-                        if Self::is_definite(&existing_entry.payload_status) {
+                    let cached = if let Some(existing_status) = cache.get_mut(&fcu) {
+                        if Self::is_definite(&existing_status) {
                             tracing::debug!(
                                 head_hash = ?head_hash,
                                 "ignoring redundant fcU cache update"
                             );
                             false
                         } else {
-                            *existing_entry = json_response.clone();
+                            *existing_status = json_response.payload_status.clone();
                             true
                         }
                     } else {
-                        cache.put(fcu.clone(), json_response.clone());
+                        cache.put(fcu.clone(), json_response.payload_status.clone());
                         true
                     };
                     drop(cache);
 
                     if cached {
-                        self.justified_block_cache
-                            .lock()
-                            .await
-                            .put(fcu.safe_block_hash, ());
-                        self.finalized_block_cache
-                            .lock()
-                            .await
-                            .put(fcu.finalized_block_hash, ());
                         tracing::info!(
                             head_hash = ?head_hash,
                             status = ?status,
                             "cached fcU from controller"
                         );
+
+                        if status == JsonPayloadStatusV1Status::Valid {
+                            self.justified_block_cache
+                                .lock()
+                                .await
+                                .put(fcu.safe_block_hash, ());
+                            self.finalized_block_cache
+                                .lock()
+                                .await
+                                .put(fcu.finalized_block_hash, ());
+                        }
                     }
 
-                    json_response
+                    json_response.payload_status
                 }
                 Err(e) => {
                     // Return an error to the controlling CL.
@@ -80,12 +86,35 @@ impl<E: EthSpec> Multiplexer<E> {
             }
         };
 
+        // FIXME: don't build payload if status is SYNCING/INVALID
+
+        // If the controller sent payload attributes, then register them with the dummy payload
+        // builder *even if* the fcU status itself was already cached. This covers the case where
+        // the controller initiallysends the fcU without payload attributes, then sends it again
+        // later *with* payload attributes.
+        let payload_id = if let Some(payload_attributes) = opt_payload_attributes {
+            match self
+                .register_attributes(head_hash, payload_attributes.into())
+                .await
+            {
+                Ok(id) => Some(TransparentJsonPayloadId(id)),
+                Err(message) => return Err(ErrorResponse::invalid_payload_attributes(id, message)),
+            }
+        } else {
+            None
+        };
+
+        let response = JsonForkchoiceUpdatedV1Response {
+            payload_status,
+            payload_id,
+        };
+
         Response::new(id, response)
     }
 
     pub async fn handle_fcu(&self, request: Request) -> Result<Response, ErrorResponse> {
-        let (id, (fcu, _payload_attributes)) =
-            request.parse_as::<(JsonForkchoiceStateV1, JsonValue)>()?;
+        let (id, (fcu, opt_payload_attributes)) =
+            request.parse_as::<(JsonForkchoiceStateV1, Option<JsonPayloadAttributes>)>()?;
 
         let head_hash = fcu.head_block_hash;
         tracing::info!(id = ?id, head_hash = ?head_hash, "processing fcU from client");
@@ -102,25 +131,44 @@ impl<E: EthSpec> Multiplexer<E> {
         }
 
         // Check cache, allowing for indefinite Syncing/Accepted responses.
-        let response = if let Some(response) = self.get_cached_fcu(&fcu, false).await {
-            if Self::is_definite(&response.payload_status) {
+        let payload_status = if let Some(payload_status) = self.get_cached_fcu(&fcu, false).await {
+            if Self::is_definite(&payload_status) {
                 tracing::debug!(id = ?id, head_hash = ?head_hash, "found definite fcU in cache");
             } else {
                 tracing::info!("sending cached indefinite status on fcU");
             }
-            response
+            payload_status
         } else {
             // Synthesise a syncing response to send, but do not cache it.
             tracing::info!(id = ?id, head_hash = ?head_hash, "sending SYNCING status on fcU");
-            JsonForkchoiceUpdatedV1Response {
-                payload_status: JsonPayloadStatusV1 {
-                    status: JsonPayloadStatusV1Status::Syncing,
-                    latest_valid_hash: None,
-                    validation_error: None,
-                },
-                payload_id: None,
+            JsonPayloadStatusV1 {
+                status: JsonPayloadStatusV1Status::Syncing,
+                latest_valid_hash: None,
+                validation_error: None,
             }
         };
+
+        // FIXME: wait for payload attributes from controller?
+        let payload_id = if let Some(payload_attributes) = opt_payload_attributes {
+            match self
+                .get_existing_payload_id(head_hash, payload_attributes.into())
+                .await
+            {
+                Ok(payload_id) => Some(TransparentJsonPayloadId(payload_id)),
+                Err(message) => {
+                    tracing::warn!(message, "unable to build payload for client");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let response = JsonForkchoiceUpdatedV1Response {
+            payload_status,
+            payload_id,
+        };
+
         Response::new(id, response)
     }
 
@@ -131,10 +179,10 @@ impl<E: EthSpec> Multiplexer<E> {
         &self,
         fcu: &JsonForkchoiceStateV1,
         definite_only: bool,
-    ) -> Option<JsonForkchoiceUpdatedV1Response> {
+    ) -> Option<JsonPayloadStatusV1> {
         let mut cache = self.fcu_cache.lock().await;
 
-        let existing_response = match self.config.fcu_matching {
+        let existing_status = match self.config.fcu_matching {
             FcuMatching::Exact => cache.get(fcu),
             FcuMatching::Loose | FcuMatching::HeadOnly => {
                 cache.iter().find_map(|(cached_fcu, res)| {
@@ -157,11 +205,10 @@ impl<E: EthSpec> Multiplexer<E> {
             }
         };
 
-        let definite_enough =
-            !definite_only || Self::is_definite(&existing_response.payload_status);
+        let definite_enough = !definite_only || Self::is_definite(&existing_status);
 
         if just_and_fin_ok && definite_enough {
-            Some(existing_response.clone())
+            Some(existing_status.clone())
         } else {
             None
         }

--- a/src/fcu.rs
+++ b/src/fcu.rs
@@ -18,7 +18,7 @@ impl<E: EthSpec> Multiplexer<E> {
             request.parse_as::<(JsonForkchoiceStateV1, Option<JsonPayloadAttributesV2>)>()?;
 
         let head_hash = fcu.head_block_hash;
-        tracing::info!(head_hash = ?head_hash, "processing fcU from controller");
+        tracing::info!(head_hash = ?head_hash, payload_attributes = ?opt_payload_attributes, "processing fcU from controller");
 
         let payload_status = if let Some(status) = self.get_cached_fcu(&fcu, true).await {
             // If fcU is cached then there should also

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod logging;
 mod meta;
 mod multiplexer;
 mod new_payload;
+mod payload_builder;
 mod transition_config;
 mod types;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,8 +125,8 @@ async fn process_client_request(
         | "eth_call"
         | ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1
         | ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1 => multiplexer.proxy_directly(request).await,
-        method @ ENGINE_GET_PAYLOAD_V1 | method @ ENGINE_GET_PAYLOAD_V2 => {
-            Err(ErrorResponse::unsupported_method(request.id, method))
+        ENGINE_GET_PAYLOAD_V1 | ENGINE_GET_PAYLOAD_V2 => {
+            multiplexer.handle_get_payload(request).await
         }
         method => Err(ErrorResponse::unsupported_method(request.id, method)),
     }
@@ -156,8 +156,8 @@ async fn handle_controller_json_rpc(
         | "eth_call"
         | ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1
         | ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1 => multiplexer.proxy_directly(request).await,
-        method @ ENGINE_GET_PAYLOAD_V1 | method @ ENGINE_GET_PAYLOAD_V2 => {
-            Err(ErrorResponse::unsupported_method(request.id, method))
+        ENGINE_GET_PAYLOAD_V1 | ENGINE_GET_PAYLOAD_V2 => {
+            multiplexer.handle_get_payload(request).await
         }
         method => Err(ErrorResponse::unsupported_method(request.id, method)),
     }

--- a/src/multiplexer.rs
+++ b/src/multiplexer.rs
@@ -4,10 +4,7 @@
 use crate::{
     config::Config,
     payload_builder::PayloadBuilder,
-    types::{
-        Auth, Engine, JsonForkchoiceStateV1, JsonForkchoiceUpdatedV1Response, JsonPayloadStatusV1,
-        TaskExecutor,
-    },
+    types::{Auth, Engine, JsonForkchoiceStateV1, JsonPayloadStatusV1, TaskExecutor},
 };
 use eth2::types::{ChainSpec, EthSpec, ExecutionBlockHash};
 use execution_layer::HttpJsonRpc;
@@ -21,7 +18,7 @@ use tokio::sync::Mutex;
 
 pub struct Multiplexer<E: EthSpec> {
     pub engine: Engine,
-    pub fcu_cache: Mutex<LruCache<JsonForkchoiceStateV1, JsonForkchoiceUpdatedV1Response>>,
+    pub fcu_cache: Mutex<LruCache<JsonForkchoiceStateV1, JsonPayloadStatusV1>>,
     pub new_payload_cache: Mutex<LruCache<ExecutionBlockHash, JsonPayloadStatusV1>>,
     pub justified_block_cache: Mutex<LruCache<ExecutionBlockHash, ()>>,
     pub finalized_block_cache: Mutex<LruCache<ExecutionBlockHash, ()>>,

--- a/src/payload_builder.rs
+++ b/src/payload_builder.rs
@@ -1,0 +1,119 @@
+use crate::Multiplexer;
+use eth2::types::{
+    EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadMerge,
+    ForkName, VariableList,
+};
+use execution_layer::PayloadAttributes;
+use lru::LruCache;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+
+type PayloadId = u64;
+
+/// Information about previously seen canonical payloads which is used for building descendant payloads.
+#[derive(Debug, Clone, Copy)]
+pub struct PayloadInfo {
+    pub block_number: u64,
+}
+
+pub struct PayloadBuilder<E: EthSpec> {
+    next_payload_id: PayloadId,
+    payload_attributes: LruCache<(ExecutionBlockHash, PayloadAttributes), PayloadId>,
+    /// Map from block hash to information about canonical, non-dummy payloads.
+    payload_info: LruCache<ExecutionBlockHash, PayloadInfo>,
+    /// Map from payload ID to dummy execution payload.
+    payloads: LruCache<PayloadId, ExecutionPayload<E>>,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> PayloadBuilder<E> {
+    pub fn new(cache_size: NonZeroUsize) -> Self {
+        Self {
+            next_payload_id: 0,
+            payload_attributes: LruCache::new(cache_size),
+            payload_info: LruCache::new(cache_size),
+            payloads: LruCache::new(cache_size),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E: EthSpec> Multiplexer<E> {
+    pub async fn register_attributes(
+        &self,
+        parent_hash: ExecutionBlockHash,
+        payload_attributes: PayloadAttributes,
+    ) -> Result<PayloadId, String> {
+        let timestamp = payload_attributes.timestamp();
+        let Some(slot) = self.timestamp_to_slot(timestamp) else {
+            return Err(format!("invalid timestamp {timestamp}"));
+        };
+
+        let mut builder = self.payload_builder.lock().await;
+        let attributes_key = (parent_hash, payload_attributes);
+        let payload_attributes = &attributes_key.1;
+
+        // Return early if payload already known/built.
+        if let Some(id) = builder.payload_attributes.get(&attributes_key) {
+            return Ok(*id);
+        }
+
+        // Check that the head block is known.
+        let Some(parent_info) = builder.payload_info.get(&parent_hash).copied() else {
+            return Err(format!("unknown parent: {parent_hash:?}"));
+        };
+
+        // Allocate a payload ID.
+        let id = builder.next_payload_id;
+
+        // Build.
+        let block_number = parent_info.block_number + 1;
+        let fee_recipient = payload_attributes.suggested_fee_recipient();
+        let prev_randao = payload_attributes.prev_randao();
+        let gas_limit = 30_000_000;
+        let fork_name = self.spec.fork_name_at_slot::<E>(slot);
+        let transactions = VariableList::new(vec![]).unwrap();
+
+        let payload = match fork_name {
+            ForkName::Merge => ExecutionPayload::Merge(ExecutionPayloadMerge {
+                parent_hash,
+                timestamp,
+                fee_recipient,
+                prev_randao,
+                block_number,
+                gas_limit,
+                transactions,
+                ..Default::default()
+            }),
+            ForkName::Capella => {
+                let withdrawals = payload_attributes
+                    .withdrawals()
+                    .map_err(|_| "no withdrawals".to_string())?
+                    .clone()
+                    .into();
+                ExecutionPayload::Capella(ExecutionPayloadCapella {
+                    parent_hash,
+                    timestamp,
+                    fee_recipient,
+                    prev_randao,
+                    block_number,
+                    gas_limit,
+                    transactions,
+                    withdrawals,
+                    ..Default::default()
+                })
+            }
+            ForkName::Base | ForkName::Altair => return Err(format!("invalid fork: {fork_name}")),
+        };
+
+        builder.payload_attributes.put(attributes_key, id);
+        builder.payloads.put(id, payload);
+        builder.next_payload_id += 1;
+
+        Ok(id)
+    }
+
+    pub fn get_payload(&mut self, payload_id: PayloadId) -> Result<ExecutionPayload<E>, String> {
+        todo!()
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,12 +7,15 @@ pub use execution_layer::{
     auth::Auth,
     engines::Engine,
     json_structures::{
-        JsonExecutionPayload, JsonForkchoiceUpdatedV1Response, JsonPayloadStatusV1,
-        JsonPayloadStatusV1Status, TransitionConfigurationV1,
+        JsonExecutionPayload, JsonForkchoiceUpdatedV1Response, JsonPayloadAttributes,
+        JsonPayloadStatusV1, JsonPayloadStatusV1Status, TransitionConfigurationV1,
+        TransparentJsonPayloadId,
     },
 };
 pub use serde_json::Value as JsonValue;
 pub use task_executor::TaskExecutor;
+
+pub type PayloadId = [u8; 8];
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -181,6 +184,28 @@ impl ErrorResponse {
             id,
             error: JsonError {
                 code: ErrorCode::InvalidRequest,
+                message,
+            },
+        }
+    }
+
+    pub fn invalid_payload_attributes(id: JsonValue, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            error: JsonError {
+                code: ErrorCode::InvalidPayloadAttributes,
+                message,
+            },
+        }
+    }
+
+    pub fn unknown_payload(id: JsonValue, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            error: JsonError {
+                code: ErrorCode::UnknownPayload,
                 message,
             },
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,8 @@ pub use execution_layer::{
     auth::Auth,
     engines::Engine,
     json_structures::{
-        JsonExecutionPayload, JsonForkchoiceUpdatedV1Response, JsonPayloadAttributes,
+        JsonExecutionPayload, JsonForkchoiceUpdatedV1Response, JsonGetPayloadResponse,
+        JsonGetPayloadResponseV1, JsonGetPayloadResponseV2, JsonPayloadAttributes,
         JsonPayloadAttributesV2, JsonPayloadStatusV1, JsonPayloadStatusV1Status,
         TransitionConfigurationV1, TransparentJsonPayloadId,
     },

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,8 +8,8 @@ pub use execution_layer::{
     engines::Engine,
     json_structures::{
         JsonExecutionPayload, JsonForkchoiceUpdatedV1Response, JsonPayloadAttributes,
-        JsonPayloadStatusV1, JsonPayloadStatusV1Status, TransitionConfigurationV1,
-        TransparentJsonPayloadId,
+        JsonPayloadAttributesV2, JsonPayloadStatusV1, JsonPayloadStatusV1Status,
+        TransitionConfigurationV1, TransparentJsonPayloadId,
     },
 };
 pub use serde_json::Value as JsonValue;


### PR DESCRIPTION
This PR adds the ability to build empty execution payloads. This _should not_ be used on mainnet. I am planning to use it only for running `blockprint`.

Closes #6.